### PR TITLE
Expose GOOGLE_CHROME_VERSION env to pin chrome

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,21 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+ARG STACK
+ARG GOOGLE_CHROME_CHANNEL
+
+# Emulate the platform where root access is not available
+RUN useradd -m -d /app non-root-user
+RUN mkdir -p /app /cache /env
+RUN chown non-root-user /app /cache /env
+USER non-root-user
+
+RUN [ -z "${GOOGLE_CHROME_CHANNEL}" ] || echo "${GOOGLE_CHROME_CHANNEL}" > /env/GOOGLE_CHROME_CHANNEL
+RUN echo "chrome_version=80.0.3987.163" > /app/google_chrome_buildpack.config
+COPY --chown=non-root-user . /buildpack
+WORKDIR /app
+
+# Sanitize the environment seen by the buildpack, to prevent reliance on
+# environment variables that won't be present when it's run by Heroku CI.
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/detect /app
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/compile /app /cache /env

--- a/bin/compile
+++ b/bin/compile
@@ -31,12 +31,35 @@ function indent() {
   esac
 }
 
+function load_config(){
+  echo "Checking Chrome version..."
+
+  local config_file="${BUILD_DIR}/google_chrome_buildpack.config"
+
+  if [ -f $config_file ];
+  then
+    source $config_file
+  else
+    error "This buildpack requires google_chrome_buildpack.config file in order to pin to a specific Chrome version."
+  fi
+
+  chrome_version=$(echo "$chrome_version" | sed 's/[^0-9.]*//g')
+
+  if [ -z "$chrome_version" ];
+  then
+    error "This buildpack requires chrome_version to be set in order to pin to a specific Chrome version."
+  fi
+}
+
 # Detect requested channel or default to stable
 if [ -f $ENV_DIR/GOOGLE_CHROME_CHANNEL ]; then
   channel=$(cat $ENV_DIR/GOOGLE_CHROME_CHANNEL)
 else
   channel=stable
 fi
+
+# Detect version of chrome to pin
+load_config
 
 # Setup bin and shim locations for desired channel, and detect invalid channels
 case "$channel" in
@@ -106,9 +129,14 @@ if [ ! -f $CACHE_DIR/PURGED_CACHE_V1 ]; then
   touch $CACHE_DIR/PURGED_CACHE_V1
 fi
 
-topic "Installing Google Chrome from the $channel channel."
+topic "Installing Google Chrome (v $chrome_version) from the $channel channel."
 
-PACKAGES="$PACKAGES https://dl.google.com/linux/direct/google-chrome-${channel}_current_amd64.deb"
+# See https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable for available versions
+
+# URL as of 7/17/2020 for downloading older stable chrome versions
+PINNED_CHROME_DEB_URL="http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${chrome_version}-1_amd64.deb"
+
+PACKAGES="$PACKAGES $PINNED_CHROME_DEB_URL"
 
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"

--- a/support/test.sh
+++ b/support/test.sh
@@ -17,6 +17,7 @@ OUTPUT_IMAGE="google-chrome-test-${STACK}"
 echo "Building buildpack on stack ${STACK}..."
 
 docker build \
+    --file Dockerfile.test \
     --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
     --build-arg "STACK=${STACK}" \
     ${GOOGLE_CHROME_CHANNEL:+--build-arg "GOOGLE_CHROME_CHANNEL=${GOOGLE_CHROME_CHANNEL}"} \


### PR DESCRIPTION
Uses the full download path linked at
https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
when hovering over the .deb download rather than the shortened stable
channel.